### PR TITLE
[tests-only][full-ci] Bump latest ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The version of OCIS to use in pipelines that test against OCIS
-OCIS_COMMITID=ociskofakecommitidhola
+OCIS_COMMITID=6bd562641e2432a6d95abbf60faadca9392c2edc
 OCIS_BRANCH=master


### PR DESCRIPTION
## Description
Bump latest ocis `stable-7.1` branch commit id.

Part of: https://github.com/owncloud/QA/issues/